### PR TITLE
Rename events to calendar

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,8 +37,8 @@ func main() {
 	scrapeProfiles := flag.Bool("profiles", false, "Alongside -scrape, signifies that professor profiles should be scraped.")
 	// Flag for soc scraping
 	scrapeOrganizations := flag.Bool("organizations", false, "Alongside -scrape, signifies that SOC organizations should be scraped.")
-	// Flag for event scraping
-	scrapeEvents := flag.Bool("events", false, "Alongside -scrape, signifies that events should be scraped.")
+	// Flag for calendar scraping
+	scrapeCalendar := flag.Bool("calendar", false, "Alongside -scrape, signifies that calendar should be scraped.")
 	// Flag for astra scraping
 	scrapeAstra := flag.Bool("astra", false, "Alongside -scrape, signifies that Astra should be scraped.")
 	// Flag for mazevo scraping
@@ -101,8 +101,8 @@ func main() {
 			scrapers.ScrapeCoursebook(*term, *startPrefix, *outDir)
 		case *scrapeOrganizations:
 			scrapers.ScrapeOrganizations(*outDir)
-		case *scrapeEvents:
-			scrapers.ScrapeEvents(*outDir)
+		case *scrapeCalendar:
+			scrapers.ScrapeCalendar(*outDir)
 		case *scrapeAstra:
 			scrapers.ScrapeAstra(*outDir)
 		case *scrapeMazevo:

--- a/scrapers/calendar.go
+++ b/scrapers/calendar.go
@@ -26,7 +26,7 @@ const CALENDAR_LINK string = "https://calendar.utdallas.edu/calendar"
 
 var trailingSpaceRegex *regexp.Regexp = regexp.MustCompile(`(\s{2,}?\s{2,})|(\n)`)
 
-func ScrapeEvents(outDir string) {
+func ScrapeCalendar(outDir string) {
 
 	chromedpCtx, cancel := utils.InitChromeDp()
 	defer cancel()


### PR DESCRIPTION
Rename the UTD Calendar scraper from `events` to `calendar` to make a better distinction between it and the other new event scrapers.