### PR TITLE
Standardize daily/weekly/... runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,19 +39,18 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         push: true 
-        tags: us-central1-docker.pkg.dev/api-tools-451421/runners/daily
-        build-args: RUN_SCRIPT_PATH=runners/daily.sh
+        tags: us-central1-docker.pkg.dev/api-tools-451421/runners/runner
 
     - name: Upload to dev job
       uses: google-github-actions/deploy-cloudrun@v2
       with:
         job: 'daily-dev'
-        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/daily'
+        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/runner'
         region: us-central1
 
     - name: Upload to prod job
       uses: google-github-actions/deploy-cloudrun@v2
       with:
         job: 'daily-prod'
-        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/daily'
+        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/runner'
         region: us-central1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches: develop
 
@@ -38,18 +39,19 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         push: true 
-        tags: us-central1-docker.pkg.dev/api-tools-451421/runners/daily-update-events
+        tags: us-central1-docker.pkg.dev/api-tools-451421/runners/daily
+        build-args: RUN_SCRIPT_PATH=runners/daily.sh
 
     - name: Upload to dev job
       uses: google-github-actions/deploy-cloudrun@v2
       with:
-        job: 'daily-update-events-dev'
-        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/daily-update-events'
+        job: 'daily-dev'
+        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/daily'
         region: us-central1
 
     - name: Upload to prod job
       uses: google-github-actions/deploy-cloudrun@v2
       with:
-        job: 'daily-update-events-prod'
-        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/daily-update-events'
+        job: 'daily-prod'
+        image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/daily'
         region: us-central1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,14 +41,14 @@ jobs:
         push: true 
         tags: us-central1-docker.pkg.dev/api-tools-451421/runners/runner
 
-    - name: Upload to dev job
+    - name: Upload to daily dev job
       uses: google-github-actions/deploy-cloudrun@v2
       with:
         job: 'daily-dev'
         image: 'us-central1-docker.pkg.dev/api-tools-451421/runners/runner'
         region: us-central1
 
-    - name: Upload to prod job
+    - name: Upload to daily prod job
       uses: google-github-actions/deploy-cloudrun@v2
       with:
         job: 'daily-prod'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.23 AS builder
 
-ARG RUN_SCRIPT_PATH
-
 WORKDIR /app
 COPY . .
 
@@ -27,7 +25,7 @@ ENV GOOGLE_CHROME_BIN /usr/bin/chromium # Also set this for compatibility
 
 # Copy build file from builder
 COPY --from=builder /app/api-tools /app/api-tools
-COPY $RUN_SCRIPT_PATH /app/$RUN_SCRIPT_PATH
+COPY runners /app/runners
 
-RUN chmod +x /app/$RUN_SCRIPT_PATH
-ENTRYPOINT ["/app/$RUN_SCRIPT_PATH"]
+RUN chmod +x /app/runners/setup.sh
+ENTRYPOINT ["/app/runners/setup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.23 AS builder
 
+ARG RUN_SCRIPT_PATH
+
 WORKDIR /app
 COPY . .
 
@@ -25,7 +27,7 @@ ENV GOOGLE_CHROME_BIN /usr/bin/chromium # Also set this for compatibility
 
 # Copy build file from builder
 COPY --from=builder /app/api-tools /app/api-tools
-COPY deploy.sh /app/deploy.sh
+COPY $RUN_SCRIPT_PATH /app/$RUN_SCRIPT_PATH
 
-RUN chmod +x /app/deploy.sh
-ENTRYPOINT ["/app/deploy.sh"]
+RUN chmod +x /app/$RUN_SCRIPT_PATH
+ENTRYPOINT ["/app/$RUN_SCRIPT_PATH"]

--- a/runners/daily.sh
+++ b/runners/daily.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-# other daily activites
-# ...
+# for daily tasks to run
 
-# Scrape, parse, and upload events
+# scrape, parse, and upload events
 ./api-tools -scrape -mazevo -verbose
 ./api-tools -parse -mazevo -verbose
 ./api-tools -scrape -astra -verbose

--- a/runners/daily.sh
+++ b/runners/daily.sh
@@ -8,7 +8,10 @@ rm service_account.json
 # .env
 gcloud secrets versions access latest --secret="$ENV_SECRET_NAME" > .env
 
-# Scrape, parse, and upload
+# other daily activites
+# ...
+
+# Scrape, parse, and upload events
 ./api-tools -scrape -mazevo -verbose
 ./api-tools -parse -mazevo -verbose
 ./api-tools -scrape -astra -verbose

--- a/runners/daily.sh
+++ b/runners/daily.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-# service account
-gcloud secrets versions access latest --secret="$SERVICE_ACCOUNT_SECRET_NAME" > service_account.json
-gcloud auth activate-service-account --key-file=service_account.json
-rm service_account.json
-
-# .env
-gcloud secrets versions access latest --secret="$ENV_SECRET_NAME" > .env
-
 # other daily activites
 # ...
 

--- a/runners/setup.sh
+++ b/runners/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# service account
+gcloud secrets versions access latest --secret="$SERVICE_ACCOUNT_SECRET_NAME" > service_account.json
+gcloud auth activate-service-account --key-file=service_account.json
+rm service_account.json
+
+# .env
+gcloud secrets versions access latest --secret="$ENV_SECRET_NAME" > .env
+
+# run commands from file specified in GCP
+sh "/app/runners/$RUNNER_SCRIPT_NAME"

--- a/runners/setup.sh
+++ b/runners/setup.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-# service account
+# auth with service account
 gcloud secrets versions access latest --secret="$SERVICE_ACCOUNT_SECRET_NAME" > service_account.json
 gcloud auth activate-service-account --key-file=service_account.json
 rm service_account.json
 
-# .env
+# use service account to access environment variables from GCP secrets, create .env
 gcloud secrets versions access latest --secret="$ENV_SECRET_NAME" > .env
 
-# run commands from file specified in GCP
+# run commands from the file path specified in the GCP run job's variable
 sh "/app/runners/$RUNNER_SCRIPT_NAME"


### PR DESCRIPTION
Makes a standard approach to running api-tools on GCP at some frequency, docs on how it works are [here](https://nebula-labs.atlassian.net/wiki/x/AYBjFw) and copied below:

> The deploy.yml GitHub action runs on push to develop and build an api-tools image on GCP using the Dockerfile. Then it sets the specified jobs to use this new image.
>
> When a job runs (based on a scheduled trigger) it starts with the runners/setup.sh script which just sets up environment variables from GCP secrets. Then based on an environment variable from the runner's config it chooses another script to run, like runners/daily.sh, which specifies which api-tools commands to run.
> 
> This allows us to have one GCP job and one scripts file per running frequency.

Right now we only have a daily runner but this should make it easy to add more with varying frequency and commands.

Note: once merged I'll delete the old jobs and images. (And we'll see if the GitHub action still works)