### PR TITLE
Improve headless mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /app
 COPY . .

--- a/utils/methods.go
+++ b/utils/methods.go
@@ -38,7 +38,14 @@ func GetEnv(name string) (string, error) {
 func InitChromeDp() (chromedpCtx context.Context, cancelFnc context.CancelFunc) {
 	log.Printf("Initializing chromedp...")
 	if Headless {
-		chromedpCtx, cancelFnc = chromedp.NewContext(context.Background())
+		opts := append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
+			chromedp.Flag("disable-dev-shm-usage", true),
+			chromedp.Flag("disable-gpu", true),
+		)
+		allocCtx, _ := chromedp.NewExecAllocator(context.Background(), opts...)
+		chromedpCtx, cancelFnc = chromedp.NewContext(allocCtx)
 	} else {
 		allocCtx, _ := chromedp.NewExecAllocator(context.Background())
 		chromedpCtx, cancelFnc = chromedp.NewContext(allocCtx)
@@ -168,6 +175,9 @@ func RefreshAstraToken(chromedpCtx context.Context) map[string][]string {
 		chromedp.WaitVisible(`body`, chromedp.ByQuery),
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			cookies, err := network.GetCookies().Do(ctx)
+			if err != nil {
+				return err
+			}
 			gotToken := false
 			for _, cookie := range cookies {
 				cookieStr = fmt.Sprintf("%s%s=%s; ", cookieStr, cookie.Name, cookie.Value)
@@ -179,7 +189,7 @@ func RefreshAstraToken(chromedpCtx context.Context) map[string][]string {
 			if !gotToken {
 				return errors.New("failed to get a new token")
 			}
-			return err
+			return nil
 		}),
 	)
 	if err != nil {

--- a/utils/methods.go
+++ b/utils/methods.go
@@ -171,8 +171,7 @@ func RefreshAstraToken(chromedpCtx context.Context) map[string][]string {
 
 	// Save all cookies to string
 	cookieStr := ""
-	_, err = chromedp.RunResponse(chromedpCtx,
-		chromedp.WaitVisible(`body`, chromedp.ByQuery),
+	err = chromedp.Run(chromedpCtx,
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			cookies, err := network.GetCookies().Do(ctx)
 			if err != nil {


### PR DESCRIPTION
The GCP runner has been hanging on `chromedp.ActionFunc` in `RefreshAstraToken` due to improper headless initialization and waiting for a redirect. Added flags to force headless and cahnged `RunResponse` to `Run` to not wait for a redirect. Tested on GCP for the past 2 days with no retries happening.