### PR TITLE
Use ISO 8601 format for log filenames

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	dateTime := time.Now()
 	year, month, day := dateTime.Date()
 	hour, min, sec := dateTime.Clock()
-	logFile, err := os.Create(fmt.Sprintf("./logs/%d-%d-%dT%d-%d-%d.log", month, day, year, hour, min, sec))
+	logFile, err := os.Create(fmt.Sprintf("./logs/%04d-%02d-%02dT%02d-%02d-%02d.log", year, month, day, hour, min, sec))
 
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	dateTime := time.Now()
 	year, month, day := dateTime.Date()
 	hour, min, sec := dateTime.Clock()
-	logFile, err := os.Create(fmt.Sprintf("./logs/%04d-%02d-%02dT%02d-%02d-%02d.log", year, month, day, hour, min, sec))
+	logFile, err := os.Create(fmt.Sprintf("./logs/%d-%02d-%02dT%02d-%02d-%02d.log", year, month, day, hour, min, sec))
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Summary
- Closes #163
- Log filenames now follow ISO 8601: `YYYY-MM-DDTHH-MM-SS.log`
- Zero-padded so they sort lexicographically

## Test plan
- [x] `go build ./...` passes
- [x] Ran the binary; confirmed a log file named like `2026-04-16T22-42-15.log` is created under `./logs/`