### PR TITLE
Fix selector for past terms in academic calendars

### DIFF
--- a/scrapers/adacemicCalendars.go
+++ b/scrapers/adacemicCalendars.go
@@ -51,7 +51,7 @@ func ScrapeAcademicCalendars(outDir string) {
 	// Selector for the scraping the calendar nodes
 	currentSel := `a.wp-block-button__link`
 	futureSel := `//h2[normalize-space(text())="Future Terms"]/following-sibling::ul[1]//a`
-	pastSel := `//h2[normalize-space(text())="Future Terms"]/following-sibling::ul[1]//a`
+	pastSel := `//h2[normalize-space(text())="Past Terms"]/following-sibling::div[1]//a`
 
 	// Extract data from links
 	// Current


### PR DESCRIPTION
Selector for past academic calendars got overridden and wasn't working. Just reverted it from before