### PR TITLE
GCP budget fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ COPY runners /app/runners
 RUN chmod +x /app/runners/setup.sh
 ENTRYPOINT ["/app/runners/setup.sh"]
 
+# Copy static-data folder for budgets and grades
+COPY static-data /app/static-data
+
 # Optional .env copy for development
 FROM base AS local
 COPY .env /app/.env

--- a/parser/budgetsParser.go
+++ b/parser/budgetsParser.go
@@ -9,8 +9,6 @@ package parser
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,7 +27,8 @@ import (
 )
 
 // What gets sent to Gemini, with the PDF content added
-// WARNING: Changes to this prompt will invalidate all cached AI responses, only change if necessary
+// WARNING: Changes to this prompt WILL NOT invalidate cached AI responses. Caching is made only based off of year
+// FOR CHANGES TO THIS PROMPT TO TAKE EFFECT THE GCP CACHE FILE MUST BE DELETED MANUALLY. The API project lead can do this for a PR
 var budgetPrompt = `Parse the content of these PDFs and generate the following JSON schema.
 
 {
@@ -414,9 +413,8 @@ func parseBudgetPdfs(paths []string) (schema.Budget, error) {
 	promptFilled := fmt.Sprintf(budgetPrompt, year, year, content)
 
 	// Check cache
-	hashByte := sha256.Sum256([]byte(promptFilled))
-	hash := hex.EncodeToString(hashByte[:]) + ".json"
-	result, err := utils.CheckCache(hash, apiBucket)
+	cacheName := year + ".json"
+	result, err := utils.CheckCache(cacheName, apiBucket)
 	if err != nil {
 		return schema.Budget{}, err
 	}
@@ -452,7 +450,7 @@ func parseBudgetPdfs(paths []string) (schema.Budget, error) {
 		result = response.Candidates[0].Content.Parts[0].Text
 
 		// Set cache for next time
-		err = utils.SetCache(hash, result, apiBucket)
+		err = utils.SetCache(cacheName, result, apiBucket)
 		if err != nil {
 			return schema.Budget{}, err
 		}


### PR DESCRIPTION
The monthly budget runner failed on GCP. Turns out it's cause the Dockerfile doesn't copy the static-data folder over into the build. That was a quick fix.

In testing tho, none of the budget caching worked and a bunch of new expensive Gemini calls were made. I'd like to avoid that so I'm proposing doing the cache by year instead of a hash. I've renamed the already cached files in the bucket and updated the warning in the code to indicate that any changes will not take effect until the cached result is cleared from the bucket