### PR TITLE
Fix year caching not updating for new PDFs

### DIFF
--- a/parser/budgetsParser.go
+++ b/parser/budgetsParser.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/UTDNebula/api-tools/utils"
 	"github.com/UTDNebula/nebula-api/api/schema"
@@ -398,12 +399,15 @@ func parseBudgetPdfs(paths []string) (schema.Budget, error) {
 	year := filepath.Base(filepath.Dir(paths[0]))
 
 	// Read PDFs
+	// WARNING: Changes to nameBuilder will invalidate all cached AI responses, only change if necessary
+	var nameBuilder strings.Builder
 	var contentBuilder strings.Builder
 	for _, path := range paths {
 		content, err := utils.ReadPdf(path, -1)
 		if err != nil {
 			return schema.Budget{}, err
 		}
+		nameBuilder.WriteString(strings.ReplaceAll(strings.ToLower(removeAllWhitespace(filepath.Base(path))), ".pdf", ""))
 		contentBuilder.WriteString("# " + filepath.Base(path) + "\n\n")
 		contentBuilder.WriteString(content + "\n\n\n")
 	}
@@ -413,7 +417,7 @@ func parseBudgetPdfs(paths []string) (schema.Budget, error) {
 	promptFilled := fmt.Sprintf(budgetPrompt, year, year, content)
 
 	// Check cache
-	cacheName := year + ".json"
+	cacheName := year + "-" + strings.TrimSpace(nameBuilder.String()) + ".json"
 	result, err := utils.CheckCache(cacheName, apiBucket)
 	if err != nil {
 		return schema.Budget{}, err
@@ -464,6 +468,18 @@ func parseBudgetPdfs(paths []string) (schema.Budget, error) {
 	}
 
 	return budget, nil
+}
+
+// Remove whitespace including non-ASCII
+// Because the 2018, 2018, and 2022 budgets have non-unicode spaces in their file names
+func removeAllWhitespace(s string) string {
+	result := make([]rune, 0, len(s))
+	for _, r := range s {
+		if !unicode.IsSpace(r) {
+			result = append(result, r)
+		}
+	}
+	return string(result)
 }
 
 // Get the storage bucket for the budget cache


### PR DESCRIPTION
A bit ago I switched to caching budget parsing using just the year (ex. "2025") instead of a hash of the whole prompt. This was because it seemed the prompt was not always consistent, likely due to some inconsistencies in `pdftotext`.

Well I realized the one time we will want it to regenerate the parsing is when a new PDF is uploaded (new as in another PDF not a new version of a preexisting PDF). Like for example 2026 only has the planned budget PDF but later the "AFR" PDF will be uploaded and we'll want the parsing to regenerate then to include all that new data.

This fixes this by hashing based off the file names. So the AI won't rerun just because of small changes due to `pdftotext` but will rerun when the hash "2026-fy26utdallasoperatingbudget(pdf).json" changes to "2026-afrfy26exhibitsa-c(pdf)fy26utdallasoperatingbudget(pdf).json"

I did not enjoy how some of the file names have non-ASCII space characters in them :/ Thanks UTD

Already uploaded new renamed cache files to the bucket